### PR TITLE
[Pynq-Z1] Add enable debug flag

### DIFF
--- a/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
+++ b/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
@@ -366,6 +366,24 @@ proc create_root_design { parentCell } {
     create_bd_addr_seg -range 0x00010000 -offset 0x43C00000 [get_bd_addr_spaces processing_system7_0/Data] [get_bd_addr_segs resize_accel_0/$::config_ip_axilite_name/Reg] SEG_resize_accel_0_Reg
   }
 
+  if { $::enable_debug == 1 } {
+    # set input DWC in to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axi_dma_0_M_AXIS_MM2S}]
+    # set output DWC out to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axis_dwidth_converter_1_M_AXIS}]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets axi_dma_0_M_AXIS_MM2S] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets axis_dwidth_converter_1_M_AXIS] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    startgroup
+        set_property -dict [list CONFIG.C_BRAM_CNT {8.5} CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
+    endgroup
+  }
+
   # Restore current instance
   current_bd_instance $oldCurInst
   validate_bd_design

--- a/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
+++ b/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
@@ -367,20 +367,22 @@ proc create_root_design { parentCell } {
   }
 
   if { $::config_enable_debug == 1 } {
+    set s2mm_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/S_AXIS_S2MM] ]
+    set mm2s_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/M_AXIS_MM2S] ]
     # set input DWC in to debug mode
-    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axi_dma_0_M_AXIS_MM2S}]
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {mm2s_net_name}]
     # set output DWC out to debug mode
-    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axis_dwidth_converter_1_M_AXIS}]
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {s2mm_net_name}]
 
     apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
     apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
-                                                          [get_bd_intf_nets axi_dma_0_M_AXIS_MM2S] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                          [get_bd_intf_nets mm2s_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
                                                          ]
     apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
-                                                          [get_bd_intf_nets axis_dwidth_converter_1_M_AXIS] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                          [get_bd_intf_nets s2mm_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
                                                          ]
     startgroup
-        set_property -dict [list CONFIG.C_BRAM_CNT {8.5} CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
+        set_property -dict [list CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
     endgroup
   }
 

--- a/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
+++ b/boards/Pynq-Z1/resizer/bitstream/resizer.tcl
@@ -366,7 +366,7 @@ proc create_root_design { parentCell } {
     create_bd_addr_seg -range 0x00010000 -offset 0x43C00000 [get_bd_addr_spaces processing_system7_0/Data] [get_bd_addr_segs resize_accel_0/$::config_ip_axilite_name/Reg] SEG_resize_accel_0_Reg
   }
 
-  if { $::enable_debug == 1 } {
+  if { $::config_enable_debug == 1 } {
     # set input DWC in to debug mode
     set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axi_dma_0_M_AXIS_MM2S}]
     # set output DWC out to debug mode

--- a/boards/Pynq-Z2/resizer/bitstream/resizer.tcl
+++ b/boards/Pynq-Z2/resizer/bitstream/resizer.tcl
@@ -365,6 +365,24 @@ proc create_root_design { parentCell } {
     connect_bd_intf_net -intf_net axi_interconnect_0_M01_AXI [get_bd_intf_pins axi_interconnect_0/M01_AXI] [get_bd_intf_pins resize_accel_0/$::config_ip_axilite_name]
     create_bd_addr_seg -range 0x00010000 -offset 0x43C00000 [get_bd_addr_spaces processing_system7_0/Data] [get_bd_addr_segs resize_accel_0/$::config_ip_axilite_name/Reg] SEG_resize_accel_0_Reg
   }
+  
+    if { $::config_enable_debug == 1 } {
+    # set input DWC in to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axi_dma_0_M_AXIS_MM2S}]
+    # set output DWC out to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axis_dwidth_converter_1_M_AXIS}]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets axi_dma_0_M_AXIS_MM2S] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets axis_dwidth_converter_1_M_AXIS] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    startgroup
+        set_property -dict [list CONFIG.C_BRAM_CNT {8.5} CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
+    endgroup
+  }
 
   # Restore current instance
   current_bd_instance $oldCurInst

--- a/boards/Pynq-Z2/resizer/bitstream/resizer.tcl
+++ b/boards/Pynq-Z2/resizer/bitstream/resizer.tcl
@@ -366,21 +366,23 @@ proc create_root_design { parentCell } {
     create_bd_addr_seg -range 0x00010000 -offset 0x43C00000 [get_bd_addr_spaces processing_system7_0/Data] [get_bd_addr_segs resize_accel_0/$::config_ip_axilite_name/Reg] SEG_resize_accel_0_Reg
   }
   
-    if { $::config_enable_debug == 1 } {
+  if { $::config_enable_debug == 1 } {
+    set s2mm_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/S_AXIS_S2MM] ]
+    set mm2s_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/M_AXIS_MM2S] ]
     # set input DWC in to debug mode
-    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axi_dma_0_M_AXIS_MM2S}]
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {mm2s_net_name}]
     # set output DWC out to debug mode
-    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {axis_dwidth_converter_1_M_AXIS}]
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {s2mm_net_name}]
 
     apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
     apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
-                                                          [get_bd_intf_nets axi_dma_0_M_AXIS_MM2S] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                          [get_bd_intf_nets mm2s_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
                                                          ]
     apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
-                                                          [get_bd_intf_nets axis_dwidth_converter_1_M_AXIS] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                          [get_bd_intf_nets s2mm_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/processing_system7_0/FCLK_CLK0" SYSTEM_ILA "Auto" APC_EN "0" } \
                                                          ]
     startgroup
-        set_property -dict [list CONFIG.C_BRAM_CNT {8.5} CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
+        set_property -dict [list CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
     endgroup
   }
 

--- a/boards/Ultra96/resizer/bitstream/resizer.tcl
+++ b/boards/Ultra96/resizer/bitstream/resizer.tcl
@@ -914,6 +914,25 @@ proc create_root_design { parentCell } {
     connect_bd_intf_net -intf_net ps8_0_axi_periph_M01_AXI [get_bd_intf_pins ps8_0_axi_periph/M01_AXI] [get_bd_intf_pins resize_accel_0/$::config_ip_axilite_name]
     create_bd_addr_seg -range 0x00010000 -offset 0xA0010000 [get_bd_addr_spaces zynq_ultra_ps_e_0/Data] [get_bd_addr_segs resize_accel_0/$::config_ip_axilite_name/Reg] SEG_resize_accel_0_Reg
   }
+  
+  if { $::config_enable_debug == 1 } {
+    set s2mm_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/S_AXIS_S2MM] ]
+    set mm2s_net_name [ get_bd_intf_nets -of_objects [get_bd_intf_pins /axi_dma_0/M_AXIS_MM2S] ]
+    # set input DWC in to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {mm2s_net_name}]
+    # set output DWC out to debug mode
+    set_property HDL_ATTRIBUTE.DEBUG true [get_bd_intf_nets {s2mm_net_name}]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets mm2s_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/zynq_ultra_ps_e_0/pl_clk0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    apply_bd_automation -rule xilinx.com:bd_rule:debug -dict [list \
+                                                          [get_bd_intf_nets s2mm_net_name] {AXIS_SIGNALS "Data and Trigger" CLK_SRC "/zynq_ultra_ps_e_0/pl_clk0" SYSTEM_ILA "Auto" APC_EN "0" } \
+                                                         ]
+    startgroup
+        set_property -dict [list CONFIG.C_DATA_DEPTH {16384}] [get_bd_cells system_ila_0]
+    endgroup
+  }
 
   # Restore current instance
   current_bd_instance $oldCurInst

--- a/boards/ip_config.tcl
+++ b/boards/ip_config.tcl
@@ -13,6 +13,7 @@ variable config_output_products_dir
 variable config_remote_cache
 variable config_util_report_filename
 variable config_ip_fclk
+variable config_enable_debug
 
 # for arguments involving paths below: use absolute paths or relative to the
 # platform/overlay/bitstream folder
@@ -48,3 +49,5 @@ set config_ip_axilite_name "s_axi_AXILiteS"
 set config_remote_cache ""
 # clock frequency
 set config_ip_fclk 100.0
+# create an ILA on main stream in/out interfaces if set to 1
+set config_enable_debug 0


### PR DESCRIPTION
Add enable debug flag to tcl script (resizer.tcl) that creates the project to insert ILA core when flag is set. When flag is set, two wires are selected for debug, the one that goes into the datawidthconverter before the accelerator and the output of the datawidthconverter that follows after the accelerator. An ILA core is inserted to make debugging of these two signals possible. 